### PR TITLE
Add Heroku's app name to Travis, and add command to run 'rake db:migrate' when travis deploy to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ deploy:
   provider: heroku
   api_key:
     secure: "33b43da3-bf16-4c42-b9e6-f6f43f25bbff"
+  app:
+    develop: fire-chess

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ deploy:
     secure: "33b43da3-bf16-4c42-b9e6-f6f43f25bbff"
   app:
     develop: fire-chess
+  run: "rake db:migrate"


### PR DESCRIPTION
I made modifications to travis.yml file:
- Add Heroku's app name to travis.yml. I realized that our github's repo is chess_app and heroku's name is fire-chess, that may be the reason why Travis did not automatically deploy to Heroku.
- Add command run: "rake db:migrate". Travis will run that command when deploying to Heroku.