### PR TITLE
Add diagonal_obstruction test & Invalid input checks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,13 +58,13 @@ Lint/UnusedBlockArgument:
 # Offense count: 4
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 250
+  Max: 500
 
 # Offense count: 24
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
-  Max: 124
+  Max: 200
 
 # Offense count: 8
 RSpec/LetSetup:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,7 +58,7 @@ Lint/UnusedBlockArgument:
 # Offense count: 4
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 136
+  Max: 250
 
 # Offense count: 24
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,6 +1,7 @@
 class Piece < ApplicationRecord
   # belongs_to :player # no player model yet
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   belongs_to :game
   validates :color, presence: true
   validates :type, presence: true
@@ -13,9 +14,18 @@ class Piece < ApplicationRecord
   #
   # def move(row,col)
   # end
-  #
-  # def is_obstructed?(dest_row, dest_col)
-  # end
+
+  def obstructed?(dest_row, dest_col)
+    if dest_row == self.x_position
+      horizontal_obstruction?
+    elsif dest_col == self.y_position
+      vertical_obstruction?
+    elsif (dest_row - self.x_position).abs == (dest_col - self.y_position).abs
+      diagonal_obstruction?
+    else
+      'Invalid input'
+    end
+  end
 
   # def horizontal_move(x,y)
   # end
@@ -31,30 +41,40 @@ class Piece < ApplicationRecord
 
 
   def vertical_obstruction?(destination_y)
-    range = self.y_position < destination_y ? (self.y_position..destination_y) : (destination_y..self.y_position)
+    range = self.y_position < destination_y ? (self.y_position...destination_y) : (destination_y...self.y_position)
     game.pieces.where(
-        color: self.color,
+        # color: self.color,
         x_position: self.x_position,
         y_position: range
       ).where.not(id: self.id).any?
   end
 
   def horizontal_obstruction?(destination_x)
-    range = self.x_position < destination_x ? (self.x_position..destination_x) : (destination_x..self.x_position)
+    range = self.x_position < destination_x ? (self.x_position...destination_x) : (destination_x...self.x_position)
     game.pieces.where(
-        color: self.color,
+        # color: self.color,
         x_position: range,
         y_position: self.y_position
       ).where.not(id: self.id).any?
   end
 
   def diagonal_obstruction?(destination_x, destination_y)
-    x_range = self.x_position < destination_x ? (self.x_position..destination_x) : (destination_x..self.x_position)
-    y_range = self.y_position < destination_y ? (self.y_position..destination_y) : (destination_y..self.y_position)
-    game.pieces.where(
-      color: self.color,
-      x_position: x_range,
-      y_position: y_range
-    ).where.not(id: self.id).any?
+    x_range = self.x_position < destination_x ? (self.x_position...destination_x) : (destination_x...self.x_position)
+    y_range = self.y_position < destination_y ? (self.y_position...destination_y) : (destination_y...self.y_position)
+    x_array = x_range.first(x_range.size)
+    y_array = y_range.first(y_range.size)
+
+    coordinates = x_array.each_with_index.map do |x, index|
+      { x: x, y: y_array[index] }
+    end
+
+    obstructions = coordinates.select do |coordinate|
+      game.pieces.where(
+        # color: self.color,
+        x_position: coordinate[:x],
+        y_position: coordinate[:y]
+      ).where.not(id: self.id).any?
+    end
+    obstructions.any?
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,5 +1,6 @@
 class Piece < ApplicationRecord
   # belongs_to :player # no player model yet
+  # rubocop:disable Metrics/AbcSize
   belongs_to :game
   validates :color, presence: true
   validates :type, presence: true
@@ -33,17 +34,27 @@ class Piece < ApplicationRecord
     range = self.y_position < destination_y ? (self.y_position..destination_y) : (destination_y..self.y_position)
     game.pieces.where(
         color: self.color,
-        x_position: self.x_position, 
+        x_position: self.x_position,
         y_position: range
       ).where.not(id: self.id).any?
   end
-  
+
   def horizontal_obstruction?(destination_x)
     range = self.x_position < destination_x ? (self.x_position..destination_x) : (destination_x..self.x_position)
     game.pieces.where(
         color: self.color,
-        x_position: range, 
+        x_position: range,
         y_position: self.y_position
       ).where.not(id: self.id).any?
+  end
+
+  def diagonal_obstruction?(destination_x, destination_y)
+    x_range = self.x_position < destination_x ? (self.x_position..destination_x) : (destination_x..self.x_position)
+    y_range = self.y_position < destination_y ? (self.y_position..destination_y) : (destination_y..self.y_position)
+    game.pieces.where(
+      color: self.color,
+      x_position: x_range,
+      y_position: y_range
+    ).where.not(id: self.id).any?
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -15,12 +15,12 @@ class Piece < ApplicationRecord
   # def move(row,col)
   # end
 
-  def obstructed?(dest_row, dest_col)
-    if dest_row == self.x_position
+  def obstructed?(destination_x, destination_y)
+    if destination_x == self.x_position
       horizontal_obstruction?
-    elsif dest_col == self.y_position
+    elsif destination_y == self.y_position
       vertical_obstruction?
-    elsif (dest_row - self.x_position).abs == (dest_col - self.y_position).abs
+    elsif (destination_x - self.x_position).abs == (destination_y - self.y_position).abs
       diagonal_obstruction?
     else
       'Invalid input'

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -1,269 +1,353 @@
 require 'rails_helper'
 
 RSpec.describe Piece, type: :model do
-  describe '#vertical_obstruction?' do
-    context 'when the destination is above me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
+  describe '#is_obstructed?' do
+    describe '#vertical_obstruction?' do
+      context 'when the destination is above me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.vertical_obstruction?(5)).to eq false
-      end
-    end
-
-    context 'when the destination is below me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
-
-      it 'is ok to move when there is nothing there' do
-        expect(piece.vertical_obstruction?(1)).to eq false
-      end
-    end
-
-    context 'when the destination is me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
-
-      it 'is ok to move when there is nothing there' do
-        expect(piece.vertical_obstruction?(3)).to eq false
-      end
-    end
-
-    context 'for every square below us' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 8 }
-
-      it 'is ok to move when there is nothing there' do
-        (1..7).each do |y|
-          expect(piece.vertical_obstruction?(y)).to eq false
-        end
-      end
-    end
-
-    context 'for every square above us' do
-      let(:piece) { FactoryGirl.build :piece, x_position: 3, y_position: 1 }
-
-      it 'is ok to move when there is nothing there' do
-        (2..8).each do |y|
-          expect(piece.vertical_obstruction?(y)).to eq false
-        end
-      end
-    end
-
-    context 'when there is a piece of mine in the way' do
-      let(:game) { FactoryGirl.create :game }
-      let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
-
-      context 'when the destination is above me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 3, y_position: 4 }
-
-        it 'is not ok to move' do
-          expect(piece.vertical_obstruction?(5)).to eq true
-        end
-      end
-
-      context 'when the destination is below me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 3, y_position: 2 }
-
-        it 'is not ok to move when there is nothing there' do
-          expect(piece.vertical_obstruction?(1)).to eq true
-        end
-      end
-    end
-
-    context 'when there is a piece of oposite color in the way' do
-      let(:game) { FactoryGirl.create :game }
-      let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
-
-      context 'when the destination is above me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 4 }
-
-        it 'is not ok to move when there is piece of oposite color there' do
+        it 'is ok to move when there is nothing there' do
           expect(piece.vertical_obstruction?(5)).to eq false
         end
       end
 
-      context 'when the destination is below me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 2 }
+      context 'when the destination is below me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
 
-        it 'is ok to move when there is piece of oposite color there' do
+        it 'is ok to move when there is nothing there' do
           expect(piece.vertical_obstruction?(1)).to eq false
         end
       end
-    end
-  end
 
-  describe '#horizontal_obstruction?' do
-    context 'when the destination is above me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
+      context 'when the destination is me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.horizontal_obstruction?(5)).to eq false
+        it 'is ok to move when there is nothing there' do
+          expect(piece.vertical_obstruction?(3)).to eq false
+        end
       end
-    end
 
-    context 'when the destination is below me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
+      context 'for every square below us' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 8 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.horizontal_obstruction?(1)).to eq false
+        it 'is ok to move when there is nothing there' do
+          (1..7).each do |y|
+            expect(piece.vertical_obstruction?(y)).to eq false
+          end
+        end
       end
-    end
 
-    context 'when the destination is me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
+      context 'for every square above us' do
+        let(:piece) { FactoryGirl.build :piece, x_position: 3, y_position: 1 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.horizontal_obstruction?(3)).to eq false
+        it 'is ok to move when there is nothing there' do
+          (2..8).each do |y|
+            expect(piece.vertical_obstruction?(y)).to eq false
+          end
+        end
       end
-    end
 
-    context 'for every square below us' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 8 }
+      context 'when there is a piece of mine in the way' do
+        let(:game) { FactoryGirl.create :game }
+        let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
 
-      it 'is ok to move when there is nothing there' do
-        (1..7).each do |x|
-          expect(piece.horizontal_obstruction?(x)).to eq false
+        context 'when the destination is above me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 3, y_position: 5 }
+
+          it 'is not ok to move' do
+            expect(piece.vertical_obstruction?(6)).to eq true
+          end
+        end
+
+        context 'when the destination is below me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 3, y_position: 2 }
+
+          it 'is not ok to move when there is nothing there' do
+            expect(piece.vertical_obstruction?(1)).to eq true
+          end
+        end
+      end
+
+      context 'when there is a piece of oposite color in the way' do
+        let(:game) { FactoryGirl.create :game }
+        let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
+
+        context 'when the destination is above me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 4 }
+
+          it 'is not ok to move when there is piece of oposite color there' do
+            expect(piece.vertical_obstruction?(5)).to eq true
+          end
+        end
+
+        context 'when the destination is below me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 2 }
+
+          it 'is not ok to move when there is piece of oposite color there' do
+            expect(piece.vertical_obstruction?(1)).to eq true
+          end
         end
       end
     end
 
-    context 'for every square above us' do
-      let(:piece) { FactoryGirl.build :piece, x_position: 3, y_position: 1 }
+    describe '#horizontal_obstruction?' do
+      context 'when the destination is above me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
 
-      it 'is ok to move when there is nothing there' do
-        (2..8).each do |x|
-          expect(piece.horizontal_obstruction?(x)).to eq false
-        end
-      end
-    end
-
-    context 'when there is a piece of mine in the way' do
-      let(:game) { FactoryGirl.create :game }
-      let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
-
-      context 'when the destination is right of me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
-
-        it 'is not ok to move' do
-          expect(piece.horizontal_obstruction?(5)).to eq true
-        end
-      end
-
-      context 'when the destination is left of me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 2, y_position: 4 }
-
-        it 'is not ok to move when there is nothing there' do
-          expect(piece.horizontal_obstruction?(1)).to eq true
-        end
-      end
-    end
-
-    context 'when there is a piece of oposite color in the way' do
-      let(:game) { FactoryGirl.create :game }
-      let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
-
-      context 'when the destination is above me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 4 }
-
-        it 'is not ok to move when there is piece of oposite color there' do
+        it 'is ok to move when there is nothing there' do
           expect(piece.horizontal_obstruction?(5)).to eq false
         end
       end
 
-      context 'when the destination is below me and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 2 }
+      context 'when the destination is below me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
 
-        it 'is ok to move when there is piece of oposite color there' do
+        it 'is ok to move when there is nothing there' do
           expect(piece.horizontal_obstruction?(1)).to eq false
         end
       end
-    end
-  end
 
-  describe '#diagonal_obstruction?' do
-    context 'when the destination is on my way up' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+      context 'when the destination is me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.diagonal_obstruction?(5, 5)).to eq false
+        it 'is ok to move when there is nothing there' do
+          expect(piece.horizontal_obstruction?(3)).to eq false
+        end
       end
-    end
 
-    context 'when the destination is on my way down' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+      context 'for every square below us' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 8 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.diagonal_obstruction?(3, 3)).to eq false
+        it 'is ok to move when there is nothing there' do
+          (1..7).each do |x|
+            expect(piece.horizontal_obstruction?(x)).to eq false
+          end
+        end
       end
-    end
 
-    context 'when the destination is me' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+      context 'for every square above us' do
+        let(:piece) { FactoryGirl.build :piece, x_position: 3, y_position: 1 }
 
-      it 'is ok to move when there is nothing there' do
-        expect(piece.diagonal_obstruction?(4, 4)).to eq false
+        it 'is ok to move when there is nothing there' do
+          (2..8).each do |x|
+            expect(piece.horizontal_obstruction?(x)).to eq false
+          end
+        end
       end
-    end
 
-    context 'for every square below us' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 8 }
+      context 'when there is a piece of mine in the way' do
+        let(:game) { FactoryGirl.create :game }
+        let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
 
-      it 'is ok to move when there is nothing there' do
-        (1..8).each do |x|
-          (1..7).each do |y|
-            expect(piece.diagonal_obstruction?(x, y)).to eq false
+        context 'when the destination is right of me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
+
+          it 'is not ok to move' do
+            expect(piece.horizontal_obstruction?(5)).to eq true
+          end
+        end
+
+        context 'when the destination is left of me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 2, y_position: 4 }
+
+          it 'is not ok to move when there is nothing there' do
+            expect(piece.horizontal_obstruction?(1)).to eq true
+          end
+        end
+      end
+
+      context 'when there is a piece of oposite color in the way' do
+        let(:game) { FactoryGirl.create :game }
+        let(:piece) { FactoryGirl.create :piece, game: game,  x_position: 3, y_position: 4 }
+
+        context 'when the destination is above me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 4 }
+
+          it 'is not ok to move when there is piece of oposite color there' do
+            expect(piece.horizontal_obstruction?(5)).to eq true
+          end
+        end
+
+        context 'when the destination is below me and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 2 }
+
+          it 'is not ok to move when there is piece of oposite color there' do
+            expect(piece.horizontal_obstruction?(1)).to eq false
           end
         end
       end
     end
 
-    context 'for every square above us' do
-      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 1 }
+    describe '#diagonal_obstruction?' do
+      context 'when the destination is up and on the right' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
 
-      it 'is ok to move when there is nothing there' do
-        (1..8).each do |x|
-          (2..8).each do |y|
-            expect(piece.diagonal_obstruction?(x, y)).to eq false
-          end
-        end
-      end
-    end
-
-    context 'when there is a piece of mine in the way' do
-      let(:game) { FactoryGirl.create :game }
-      let(:piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
-
-      context 'when the destination is on my way up and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
-
-        it 'is not ok to move' do
-          expect(piece.diagonal_obstruction?(5, 5)).to eq true
-        end
-      end
-
-      context 'when the destination is on my way down and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 4, y_position: 2 }
-
-        it 'is not ok to move when there is nothing there' do
-          expect(piece.diagonal_obstruction?(3, 1)).to eq true
-        end
-      end
-    end
-
-    context 'when there is a piece of opposite color in the way' do
-      let(:game) { FactoryGirl.create :game }
-      let(:piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
-
-      context 'when the destination is on my way up and there is piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 4, y_position: 4 }
-
-        it 'is not ok to move when there is a piece of opposite color there' do
+        it 'is ok to move when there is nothing there' do
           expect(piece.diagonal_obstruction?(6, 6)).to eq false
         end
       end
 
-      context 'when the destination is on my way down and there is a piece in the way' do
-        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 4, y_position: 2 }
+      context 'when the destination is up and on the left' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
 
-        it 'is ok to move when there is a piece of opposite color there' do
-          expect(piece.diagonal_obstruction?(3, 1)).to eq false
+        it 'is ok to move when there is nothing there' do
+          expect(piece.diagonal_obstruction?(2, 6)).to eq false
+        end
+      end
+
+      context 'when the destination is down and on the right' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'is ok to move when there is nothing there' do
+          expect(piece.diagonal_obstruction?(6, 2)).to eq false
+        end
+      end
+
+      context 'when the destination is down and on the left' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'is ok to move when there is nothing there' do
+          expect(piece.diagonal_obstruction?(2, 2)).to eq false
+        end
+      end
+
+      context 'when the destination is me' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'is ok to move when there is nothing there' do
+          expect(piece.diagonal_obstruction?(4, 4)).to eq false
+        end
+      end
+
+      context 'for every square below us' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 8 }
+
+        it 'is ok to move when there is nothing there' do
+          (1..8).each do |x|
+            (1..7).each do |y|
+              expect(piece.diagonal_obstruction?(x, y)).to eq false
+            end
+          end
+        end
+      end
+
+      context 'for every square above us' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 1 }
+
+        it 'is ok to move when there is nothing there' do
+          (1..8).each do |x|
+            (2..8).each do |y|
+              expect(piece.diagonal_obstruction?(x, y)).to eq false
+            end
+          end
+        end
+      end
+
+      context 'when there is a piece of mine in the way' do
+        let(:game) { FactoryGirl.create :game }
+        let(:piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
+
+        context 'when the destination is up and on the right, and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 5, y_position: 5 }
+
+          it 'is not ok to move' do
+            expect(piece.diagonal_obstruction?(6, 6)).to eq true
+          end
+        end
+
+        context 'when the destination is up and on the left, and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 3, y_position: 5 }
+
+          it 'is not ok to move' do
+            expect(piece.diagonal_obstruction?(2, 6)).to eq true
+          end
+        end
+
+        context 'when the destination is down and on the right, and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 5, y_position: 3 }
+
+          it 'is not ok to move when there is nothing there' do
+            expect(piece.diagonal_obstruction?(6, 2)).to eq true
+          end
+        end
+
+        context 'when the destination is down and on the left, and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 3, y_position: 3 }
+
+          it 'is not ok to move when there is nothing there' do
+            expect(piece.diagonal_obstruction?(2, 2)).to eq true
+          end
+        end
+      end
+
+      context 'when there is a piece of opposite color in the way' do
+        let(:game) { FactoryGirl.create :game }
+        let(:piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
+
+        context 'when the destination is up and on the right, and there is piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 5, y_position: 5 }
+
+          it 'is not ok to move when there is a piece of opposite color there' do
+            expect(piece.diagonal_obstruction?(6, 6)).to eq true
+          end
+        end
+
+        context 'when the destination is up and on the left, and there is piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 5 }
+
+          it 'is not ok to move when there is a piece of opposite color there' do
+            expect(piece.diagonal_obstruction?(2, 6)).to eq true
+          end
+        end
+
+        context 'when the destination is down and on the right, and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 5, y_position: 3 }
+
+          it 'is not ok to move when there is a piece of opposite color there' do
+            expect(piece.diagonal_obstruction?(6, 2)).to eq true
+          end
+        end
+
+        context 'when the destination is down and on the left, and there is a piece in the way' do
+          let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 3, y_position: 3 }
+
+          it 'is not ok to move when there is a piece of opposite color there' do
+            expect(piece.diagonal_obstruction?(2, 2)).to eq true
+          end
+        end
+      end
+    end
+
+    describe '#invalid input' do
+      context 'when the destination is up and on the left, and the piece is not moving horizontally, vertically, or horizontally' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'will raise an error' do
+          expect(piece.obstructed?(2, 5)). to eq 'Invalid input'
+        end
+      end
+
+      context 'when the destination is up and on the right, and the piece is not moving horizontally, vertically, or horizontally' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'will raise an error' do
+          expect(piece.obstructed?(5, 6)). to eq 'Invalid input'
+        end
+      end
+
+      context 'when the destination is down and on the left, and the piece is not moving horizontally, vertically, or horizontally' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'will raise an error' do
+          expect(piece.obstructed?(3, 2)). to eq 'Invalid input'
+        end
+      end
+
+      context 'when the destination is down and on the right, and the piece is not moving horizontally, vertically, or horizontally' do
+        let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+        it 'will raise an error' do
+          expect(piece.obstructed?(6, 3)). to eq 'Invalid input'
         end
       end
     end

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Piece, type: :model do
       end
     end
   end
-  
+
   describe '#horizontal_obstruction?' do
     context 'when the destination is above me' do
       let(:piece) { FactoryGirl.create :piece, x_position: 3, y_position: 3 }
@@ -172,6 +172,98 @@ RSpec.describe Piece, type: :model do
 
         it 'is ok to move when there is piece of oposite color there' do
           expect(piece.horizontal_obstruction?(1)).to eq false
+        end
+      end
+    end
+  end
+
+  describe '#diagonal_obstruction?' do
+    context 'when the destination is on my way up' do
+      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+      it 'is ok to move when there is nothing there' do
+        expect(piece.diagonal_obstruction?(5, 5)).to eq false
+      end
+    end
+
+    context 'when the destination is on my way down' do
+      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+      it 'is ok to move when there is nothing there' do
+        expect(piece.diagonal_obstruction?(3, 3)).to eq false
+      end
+    end
+
+    context 'when the destination is me' do
+      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 4 }
+
+      it 'is ok to move when there is nothing there' do
+        expect(piece.diagonal_obstruction?(4, 4)).to eq false
+      end
+    end
+
+    context 'for every square below us' do
+      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 8 }
+
+      it 'is ok to move when there is nothing there' do
+        (1..8).each do |x|
+          (1..7).each do |y|
+            expect(piece.diagonal_obstruction?(x, y)).to eq false
+          end
+        end
+      end
+    end
+
+    context 'for every square above us' do
+      let(:piece) { FactoryGirl.create :piece, x_position: 4, y_position: 1 }
+
+      it 'is ok to move when there is nothing there' do
+        (1..8).each do |x|
+          (2..8).each do |y|
+            expect(piece.diagonal_obstruction?(x, y)).to eq false
+          end
+        end
+      end
+    end
+
+    context 'when there is a piece of mine in the way' do
+      let(:game) { FactoryGirl.create :game }
+      let(:piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
+
+      context 'when the destination is on my way up and there is a piece in the way' do
+        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
+
+        it 'is not ok to move' do
+          expect(piece.diagonal_obstruction?(5, 5)).to eq true
+        end
+      end
+
+      context 'when the destination is on my way down and there is a piece in the way' do
+        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: piece.color, x_position: 4, y_position: 2 }
+
+        it 'is not ok to move when there is nothing there' do
+          expect(piece.diagonal_obstruction?(3, 1)).to eq true
+        end
+      end
+    end
+
+    context 'when there is a piece of opposite color in the way' do
+      let(:game) { FactoryGirl.create :game }
+      let(:piece) { FactoryGirl.create :piece, game: game, x_position: 4, y_position: 4 }
+
+      context 'when the destination is on my way up and there is piece in the way' do
+        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 4, y_position: 4 }
+
+        it 'is not ok to move when there is a piece of opposite color there' do
+          expect(piece.diagonal_obstruction?(6, 6)).to eq false
+        end
+      end
+
+      context 'when the destination is on my way down and there is a piece in the way' do
+        let!(:obstructing_piece) { FactoryGirl.create :piece, game: game, color: 'black', x_position: 4, y_position: 2 }
+
+        it 'is ok to move when there is a piece of opposite color there' do
+          expect(piece.diagonal_obstruction?(3, 1)).to eq false
         end
       end
     end


### PR DESCRIPTION
Changes to this commit:
- Add diagonal_check to see if there is an obstruction or not.
- Add tests that test out the diagonal_check.
- Add the all the range to exclude the destination point, since we only need to check all the space in between.
- Comment out color: self.color since we are only checking in between, not starting point or destination point, it doesn't matter which color the piece is.
- Add obstructed? method in Piece model to include all three checks, and raise an error when a piece is not moving either vertically, horizontally, or diagonally.
- Add new tests to test out invalid move.
- Add minor edit to some tests, correct the obstructing piece position for all tests.
- Add minor edit to rubocop.